### PR TITLE
タスクが終わった後にpending中の親タスクにもフォーカスするようにした

### DIFF
--- a/src/adapter/controller/schronu.rs
+++ b/src/adapter/controller/schronu.rs
@@ -1103,22 +1103,8 @@ fn execute_finish(focused_task_id_opt: &mut Option<Uuid>, focused_task_opt: &Opt
             None => {}
         }
 
-        // もし親タスクがTodoでないならば、フォーカスを外す
-        match focused_task.parent().map(|t| t.get_status()) {
-            Some(Status::Todo) => {
-                // do nothing
-            }
-            _ => {
-                *focused_task_id_opt = None;
-
-                // dummy
-                return None::<i32>;
-            }
-        }
-
-        // 親タスクがTodoの時
-        // 兄弟タスクが無い場合は、フォーカスを親タスクに移す。
-        // そうでない場合は、フォーカスを外す。
+        // 兄弟タスクが全て完了している場合は、フォーカスを親タスクに移す。
+        // そうでなければ、フォースを外す
         *focused_task_id_opt = if focused_task.all_sibling_tasks_are_all_done() {
             focused_task.parent().map(|t| t.get_id())
         } else {


### PR DESCRIPTION
これまではタスクが終わった後に親タスクがpendingの場合はフォーカスしていなかったが、それだと割コマンドが使いにくいのでフォーカスするようにした