### PR TITLE
show_all_tasks()の表示修正

### DIFF
--- a/src/adapter/controller/schronu.rs
+++ b/src/adapter/controller/schronu.rs
@@ -625,8 +625,23 @@ fn execute_show_all_tasks(
             Weekday::Sun => "日",
         };
 
-        let free_time_minutes = if date == &&last_synced_time.date_naive() {
-            free_time_manager.get_free_minutes(&last_synced_time, &eod)
+        let local_datetime_base = get_next_morning_datetime(
+            Local::now()
+                .timezone()
+                .from_local_datetime(&date.and_hms_opt(0, 0, 0).unwrap())
+                .unwrap(),
+        );
+
+        let free_time_minutes = if last_synced_time.hour()
+            < get_next_morning_datetime(last_synced_time).hour()
+            && local_datetime_base < last_synced_time
+            && last_synced_time < get_next_morning_datetime(local_datetime_base)
+        {
+            if last_synced_time < eod {
+                (eod - last_synced_time).num_minutes()
+            } else {
+                0
+            }
         } else {
             let local_tz = Local::now().timezone();
 


### PR DESCRIPTION
[show_all_task()で、葉ノードだけでなく全てのノードを日ごとの統計に反映させるようにした](https://github.com/sakabar/Schronu/commit/882716694e181db4e6dcfe5b59fa156fea8c83f7)
[[Bugfix] 日付を超えるとshow_all_task()のfree_time計算がおかしくなる不具合を修正した](https://github.com/sakabar/Schronu/commit/e785a2015b1f0c2217406b82c2ab81f6b8a8af60)