### PR TITLE
show_all_tasks()の日付や〆切まわりのバグ修正

### DIFF
--- a/src/adapter/controller/schronu.rs
+++ b/src/adapter/controller/schronu.rs
@@ -479,7 +479,7 @@ fn execute_show_all_tasks(
                 if (rank == &0 && dt < &eod)
                     || (task.get_deadline_time_opt().is_some()
                         && task.get_deadline_time_opt().unwrap()
-                            < last_synced_time + Duration::days(1))
+                            < get_next_morning_datetime(last_synced_time))
                 {
                     total_deadline_estimated_work_seconds += task.get_estimated_work_seconds();
                 }
@@ -505,7 +505,8 @@ fn execute_show_all_tasks(
                 let today_leaf_icon: String = "/".to_string();
                 // Todo: この判定が分散しているので、後で関数化したほうがよいかも
                 let icon = if task.get_deadline_time_opt().is_some()
-                    && task.get_deadline_time_opt().unwrap() < last_synced_time + Duration::days(1)
+                    && task.get_deadline_time_opt().unwrap()
+                        < get_next_morning_datetime(last_synced_time)
                 {
                     &deadline_icon
                 } else if rank == &0 && dt < &eod {
@@ -536,7 +537,7 @@ fn execute_show_all_tasks(
                             if rank == &0
                                 || task.get_deadline_time_opt().is_some()
                                     && task.get_deadline_time_opt().unwrap()
-                                        < last_synced_time + Duration::days(1)
+                                        < get_next_morning_datetime(last_synced_time)
                             {
                                 msgs_with_dt.push((*dt, *rank, msg));
                             }

--- a/src/entity/task.rs
+++ b/src/entity/task.rs
@@ -1290,7 +1290,7 @@ impl Task {
                     child_task_first_available_time = *dt_cand.iter().max().unwrap();
 
                     // 〆切優先
-                    match self.get_deadline_time_opt() {
+                    match task.get_deadline_time_opt() {
                         Some(deadline_time) => {
                             child_task_first_available_time =
                                 min(child_task_first_available_time, deadline_time);


### PR DESCRIPTION
[「全 印」や「全 〆」のアイコン設定の条件が誤っており、0時を回った後に実行するとおかしくなっていたのを修正](https://github.com/sakabar/Schronu/commit/56828b33684a95d75622e8c893d6254f5957a3c8)
[list_all_parent_tasks_with_first_available_time()のバグ修正](https://github.com/sakabar/Schronu/commit/a24abbed70b584568439070049d438cf8465907f)