### PR TITLE
繰り返しタスクの見積り補正で、これまで2分以内のズレを誤差の範囲としていたところを1分以内に変更した。

### DIFF
--- a/src/adapter/controller/schronu.rs
+++ b/src/adapter/controller/schronu.rs
@@ -1789,8 +1789,7 @@ fn execute_finish(focused_task_id_opt: &mut Option<Uuid>, focused_task_opt: &Opt
                             // 2分探索の気分で、2で割るのを基本としたかったが、人は見積もりを過小評価しがちなので、大きくする方向については75%採用する
                             let new_estimated_work_seconds = orig_estimated_sec + diff * 3 / 4;
                             parent_task.set_estimated_work_seconds(new_estimated_work_seconds);
-                        } else if diff <= -120 {
-                            // 予定より2分以内早いというズレは誤差の範囲とする
+                        } else if diff < 0 {
                             // 見積もりは最短でも1分になるようにする
                             // 人は見積もりを過小評価しがちなので、見積もりをさらに小さくする方向については慎重に。25%採用する
                             let new_estimated_work_seconds = max(60, orig_estimated_sec + diff / 4);


### PR DESCRIPTION
1分以内に終わるタスクが1分扱いになることと、2分以内の早い完了を誤差扱いしていたことにより、実質数秒で終わるタスクが3分かかることになっていた。

このようなタスクが仮に10個積み重なると30分のズレとなってしまう。

今、タスクがパンパンな状態であるため、悲観的に見すぎずに現実的な値が入力されるようにする。