### PR TITLE
WコマンドのStatus設定を修正

### DIFF
--- a/src/adapter/controller/schronu.rs
+++ b/src/adapter/controller/schronu.rs
@@ -3499,10 +3499,7 @@ fn application(
                                         focused_task.unset_deadline_time_opt();
                                         focused_task.set_deadline_time_opt(Some(new_deadline_time));
 
-                                        let p = get_next_morning_datetime(new_deadline_time)
-                                            - Duration::days(1);
-                                        focused_task.set_pending_until(p);
-                                        focused_task.set_orig_status(Status::Pending);
+                                        focused_task.set_orig_status(Status::Todo);
 
                                         // 〆切の日に合わせる
                                         let new_start_time = focused_task.get_start_time()


### PR DESCRIPTION
days_in_advanceが設定されているタスクに対してWコマンドで未来に送った場合に、pending_untilがあるせいでstart_time通りの時刻に開始しないバグを修正