### PR TITLE
:sparkles: Feat: 繰り返しタスクの基準日を明示化

### DIFF
--- a/src/adapter/controller/schronu.rs
+++ b/src/adapter/controller/schronu.rs
@@ -11,7 +11,7 @@ use schronu::application::interface::TaskRepositoryTrait;
 use schronu::entity::datetime::{get_next_morning_datetime, parse_local_datetime};
 use schronu::entity::task::{
     extract_leaf_tasks_from_project, extract_leaf_tasks_from_project_with_pending,
-    round_up_sec_as_minute, Status, Task, TaskAttr,
+    round_up_sec_as_minute, RepetitionAnchor, Status, Task, TaskAttr,
 };
 use std::cmp::max;
 use std::cmp::min;
@@ -133,6 +133,37 @@ fn parse_clear_or_gather_defer_to_datetime(
 mod tests {
     use super::*;
 
+    fn next_child_after_finish(
+        repetition_anchor: RepetitionAnchor,
+        days_in_advance: i64,
+        focused_start_time: DateTime<Local>,
+        focused_deadline_time_opt: Option<DateTime<Local>>,
+        finished_at: DateTime<Local>,
+    ) -> Task {
+        let parent_task = Task::new("ルーチン");
+        parent_task.set_repetition_interval_days_opt(Some(7));
+        parent_task.set_repetition_anchor(repetition_anchor);
+        parent_task.set_days_in_advance(days_in_advance);
+        parent_task.set_start_time(Local.with_ymd_and_hms(2026, 5, 10, 9, 30, 15).unwrap());
+        parent_task.set_deadline_time_opt(Some(
+            Local.with_ymd_and_hms(2026, 5, 10, 23, 59, 59).unwrap(),
+        ));
+
+        let mut child_task_attr = TaskAttr::new("ルーチン(5/16)");
+        child_task_attr.set_start_time(focused_start_time);
+        child_task_attr.set_deadline_time_opt(focused_deadline_time_opt);
+        let child_task = parent_task.create_as_last_child(child_task_attr);
+
+        let mut focused_task_id_opt = Some(child_task.get_id());
+        execute_finish(&mut focused_task_id_opt, &Some(child_task), finished_at);
+
+        parent_task
+            .get_children()
+            .into_iter()
+            .find(|task| task.get_status() != Status::Done)
+            .expect("next repetition child")
+    }
+
     #[test]
     fn test_get_adjustable_prefix_label_前倒し可能日数を表示する() {
         let task = Task::new("タスク");
@@ -234,6 +265,74 @@ mod tests {
         let actual = parse_clear_or_gather_defer_to_datetime("集", "120", now);
 
         assert_eq!(actual, Some(now + Duration::minutes(120)));
+    }
+
+    #[test]
+    fn test_execute_finish_repetition_anchor_deadlineは元の期限サイクルを維持する() {
+        let next_child = next_child_after_finish(
+            RepetitionAnchor::Deadline,
+            0,
+            Local.with_ymd_and_hms(2026, 5, 16, 9, 30, 15).unwrap(),
+            Some(Local.with_ymd_and_hms(2026, 5, 16, 23, 59, 59).unwrap()),
+            Local.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap(),
+        );
+
+        assert_eq!(
+            next_child.get_deadline_time_opt(),
+            Some(Local.with_ymd_and_hms(2026, 5, 23, 23, 59, 59).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_execute_finish_repetition_anchor_completionは完了日から次回期限を決める() {
+        let next_child = next_child_after_finish(
+            RepetitionAnchor::Completion,
+            0,
+            Local.with_ymd_and_hms(2026, 5, 16, 9, 30, 15).unwrap(),
+            Some(Local.with_ymd_and_hms(2026, 5, 16, 23, 59, 59).unwrap()),
+            Local.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap(),
+        );
+
+        assert_eq!(
+            next_child.get_deadline_time_opt(),
+            Some(Local.with_ymd_and_hms(2026, 5, 24, 23, 59, 59).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_execute_finish_days_in_advanceはstart_timeだけ前倒しする() {
+        let next_child = next_child_after_finish(
+            RepetitionAnchor::Deadline,
+            2,
+            Local.with_ymd_and_hms(2026, 5, 16, 9, 30, 15).unwrap(),
+            Some(Local.with_ymd_and_hms(2026, 5, 16, 23, 59, 59).unwrap()),
+            Local.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap(),
+        );
+
+        assert_eq!(
+            next_child.get_start_time(),
+            Local.with_ymd_and_hms(2026, 5, 21, 9, 30, 15).unwrap()
+        );
+        assert_eq!(
+            next_child.get_deadline_time_opt(),
+            Some(Local.with_ymd_and_hms(2026, 5, 23, 23, 59, 59).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_execute_finish_deadlineがない場合はcompletionにfallbackする() {
+        let next_child = next_child_after_finish(
+            RepetitionAnchor::Deadline,
+            0,
+            Local.with_ymd_and_hms(2026, 5, 16, 9, 30, 15).unwrap(),
+            None,
+            Local.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap(),
+        );
+
+        assert_eq!(
+            next_child.get_deadline_time_opt(),
+            Some(Local.with_ymd_and_hms(2026, 5, 24, 23, 59, 59).unwrap())
+        );
     }
 
     #[test]
@@ -3139,16 +3238,76 @@ fn execute_defer_all_frequent_routines(
     // println!("{:?}", cnt );
 }
 
-fn execute_finish(focused_task_id_opt: &mut Option<Uuid>, focused_task_opt: &Option<Task>) {
+fn apply_time_template(
+    base_datetime: DateTime<Local>,
+    time_template: DateTime<Local>,
+) -> DateTime<Local> {
+    base_datetime
+        .with_hour(time_template.hour())
+        .expect("invalid hour")
+        .with_minute(time_template.minute())
+        .expect("invalid minute")
+        .with_second(time_template.second())
+        .expect("invalid second")
+        .with_nanosecond(0)
+        .expect("invalid nanosecond")
+}
+
+fn build_next_repetition_task_attr(
+    focused_task: &Task,
+    parent_task: &Task,
+    repetition_interval_days: i64,
+    finished_at: DateTime<Local>,
+) -> TaskAttr {
+    let occurrence_anchor = match parent_task.get_repetition_anchor() {
+        RepetitionAnchor::Deadline => focused_task.get_deadline_time_opt().unwrap_or(finished_at),
+        RepetitionAnchor::Completion => finished_at,
+    };
+    let next_occurrence_day =
+        get_next_morning_datetime(occurrence_anchor) + Duration::days(repetition_interval_days - 1);
+    let parent_task_start_time = parent_task.get_start_time();
+    let new_start_time = apply_time_template(next_occurrence_day, parent_task_start_time);
+    let new_deadline_time = match parent_task.get_deadline_time_opt() {
+        Some(parent_task_deadline_time) => {
+            apply_time_template(next_occurrence_day, parent_task_deadline_time)
+        }
+        None => new_start_time
+            .with_hour(23)
+            .expect("invalid hour")
+            .with_minute(59)
+            .expect("invalid minute")
+            .with_second(59)
+            .expect("invalid second")
+            .with_nanosecond(0)
+            .expect("invalid nanosecond"),
+    };
+    let new_task_name = format!(
+        "{}({}/{})",
+        parent_task.get_name(),
+        new_start_time.month(),
+        new_start_time.day()
+    );
+
+    let mut new_task_attr = TaskAttr::new(&new_task_name);
+    new_task_attr
+        .set_start_time(new_start_time - Duration::days(parent_task.get_days_in_advance()));
+    new_task_attr.set_deadline_time_opt(Some(new_deadline_time));
+    new_task_attr.set_estimated_work_seconds(parent_task.get_estimated_work_seconds());
+    new_task_attr
+}
+
+fn execute_finish(
+    focused_task_id_opt: &mut Option<Uuid>,
+    focused_task_opt: &Option<Task>,
+    finished_at: DateTime<Local>,
+) {
     focused_task_opt.as_ref().and_then(|focused_task| {
         focused_task.set_orig_status(Status::Done);
-        focused_task.set_end_time_opt(Some(Local::now()));
+        focused_task.set_end_time_opt(Some(finished_at));
 
         // 親タスクがrepetition_interval_daysを持っているなら、
         // その値に従って兄弟ノードを生成する
-        // start_timeは日付は(repetition_interval_days-1)日後で、時刻は親タスクのstart_timeを引き継ぐ
         // タスク名は「親タスク名(日付)」
-        // deadline_timeの時刻は親タスクのdeadline_timeを引き継ぐ (無ければ23:59)
         // estimated_work_secondsは親タスクを引き継ぐ
         match focused_task.parent() {
             Some(parent_task) => match parent_task.get_repetition_interval_days_opt() {
@@ -3173,49 +3332,12 @@ fn execute_finish(focused_task_id_opt: &mut Option<Uuid>, focused_task_opt: &Opt
                         }
                     }
 
-                    let parent_task_name = parent_task.get_name();
-                    let parent_task_start_time = parent_task.get_start_time();
-                    let days_in_advance = parent_task.get_days_in_advance();
-                    let new_start_time = get_next_morning_datetime(
-                        Local::now() + Duration::days(repetition_interval_days - 1),
-                    )
-                    .with_hour(parent_task_start_time.hour())
-                    .unwrap()
-                    .with_minute(parent_task_start_time.minute())
-                    .unwrap()
-                    .with_second(parent_task_start_time.second())
-                    .unwrap()
-                    .with_nanosecond(0)
-                    .unwrap();
-                    let new_task_month = new_start_time.month();
-                    let new_task_day = new_start_time.day();
-                    let new_task_name =
-                        format!("{}({}/{})", parent_task_name, new_task_month, new_task_day);
-
-                    let new_deadline_time = match parent_task.get_deadline_time_opt() {
-                        Some(parent_task_deadline_time) => new_start_time
-                            .with_hour(parent_task_deadline_time.hour())
-                            .unwrap()
-                            .with_minute(parent_task_deadline_time.minute())
-                            .unwrap()
-                            .with_nanosecond(0)
-                            .unwrap(),
-                        None => new_start_time
-                            .with_hour(23)
-                            .unwrap()
-                            .with_minute(59)
-                            .unwrap()
-                            .with_second(59)
-                            .unwrap(),
-                    };
-
-                    let estimated_work_seconds = parent_task.get_estimated_work_seconds();
-
-                    let mut new_task_attr = TaskAttr::new(&new_task_name);
-                    // deadlineの決定などに影響を与えたくないので、最後にdays_in_advanceを引く
-                    new_task_attr.set_start_time(new_start_time - Duration::days(days_in_advance));
-                    new_task_attr.set_deadline_time_opt(Some(new_deadline_time));
-                    new_task_attr.set_estimated_work_seconds(estimated_work_seconds);
+                    let new_task_attr = build_next_repetition_task_attr(
+                        focused_task,
+                        &parent_task,
+                        repetition_interval_days,
+                        finished_at,
+                    );
                     parent_task.create_as_last_child(new_task_attr);
                 }
                 None => {}
@@ -4215,7 +4337,11 @@ fn execute(
                     }
 
                     // 完了操作
-                    execute_finish(focused_task_id_opt, &focused_task_opt);
+                    execute_finish(
+                        focused_task_id_opt,
+                        &focused_task_opt,
+                        task_repository.get_last_synced_time(),
+                    );
                 }
             }
         }

--- a/src/adapter/gateway/yaml.rs
+++ b/src/adapter/gateway/yaml.rs
@@ -1,4 +1,5 @@
 use crate::entity::datetime::parse_local_datetime;
+use crate::entity::task::read_repetition_anchor;
 use crate::entity::task::read_status;
 use crate::entity::task::Status;
 use crate::entity::task::{ImmutableTask, Task, TaskAttr};
@@ -13,6 +14,9 @@ use yaml_rust::YamlLoader;
 
 #[cfg(test)]
 use crate::entity::task::assert_task;
+
+#[cfg(test)]
+use crate::entity::task::RepetitionAnchor;
 
 #[cfg(test)]
 use uuid::uuid;
@@ -300,6 +304,8 @@ pub fn yaml_to_task(yaml: &Yaml, now: DateTime<Local>) -> Task {
         .unwrap_or(default_attr.get_actual_work_seconds());
 
     let repetition_interval_days_opt: Option<i64> = yaml["repetition_interval_days"].as_i64();
+    let repetition_anchor_str: &str = yaml["repetition_anchor"].as_str().unwrap_or("");
+    let repetition_anchor = read_repetition_anchor(repetition_anchor_str);
     let days_in_advance: i64 = yaml["days_in_advance"]
         .as_i64()
         .unwrap_or(default_attr.get_days_in_advance());
@@ -346,6 +352,7 @@ pub fn yaml_to_task(yaml: &Yaml, now: DateTime<Local>) -> Task {
     parent_task.set_estimated_work_seconds(estimated_work_seconds);
     parent_task.set_actual_work_seconds(actual_work_seconds);
     parent_task.set_repetition_interval_days_opt(repetition_interval_days_opt);
+    parent_task.set_repetition_anchor(repetition_anchor);
     parent_task.set_days_in_advance(days_in_advance);
 
     // repetition_interval_daysを持つタスクがtodoのままだと、
@@ -767,6 +774,65 @@ repetition_interval_days: 7
     expected.set_orig_status(Status::Pending);
     expected.set_pending_until(distant_future);
 
+    expected.sync_clock(now);
+
+    assert_task(&actual, &expected);
+}
+
+#[test]
+fn test_yaml_to_task_repetition_anchor_completionキー_正常系() {
+    let s = "
+name: 'タスク1'
+status: 'todo'
+repetition_anchor: completion
+";
+
+    let docs = YamlLoader::load_from_str(s).unwrap();
+    let project_yaml: &Yaml = &docs[0];
+
+    let now = Local::now();
+    let actual = yaml_to_task(project_yaml, now);
+    let expected = Task::new("タスク1");
+    expected.set_repetition_anchor(RepetitionAnchor::Completion);
+    expected.sync_clock(now);
+
+    assert_task(&actual, &expected);
+}
+
+#[test]
+fn test_yaml_to_task_repetition_anchor未指定ならdeadline() {
+    let s = "
+name: 'タスク1'
+status: 'todo'
+";
+
+    let docs = YamlLoader::load_from_str(s).unwrap();
+    let project_yaml: &Yaml = &docs[0];
+
+    let now = Local::now();
+    let actual = yaml_to_task(project_yaml, now);
+    let expected = Task::new("タスク1");
+    expected.set_repetition_anchor(RepetitionAnchor::Deadline);
+    expected.sync_clock(now);
+
+    assert_task(&actual, &expected);
+}
+
+#[test]
+fn test_yaml_to_task_repetition_anchor不正値ならdeadline() {
+    let s = "
+name: 'タスク1'
+status: 'todo'
+repetition_anchor: invalid
+";
+
+    let docs = YamlLoader::load_from_str(s).unwrap();
+    let project_yaml: &Yaml = &docs[0];
+
+    let now = Local::now();
+    let actual = yaml_to_task(project_yaml, now);
+    let expected = Task::new("タスク1");
+    expected.set_repetition_anchor(RepetitionAnchor::Deadline);
     expected.sync_clock(now);
 
     assert_task(&actual, &expected);

--- a/src/entity/task.rs
+++ b/src/entity/task.rs
@@ -62,6 +62,28 @@ pub fn read_status(s: &str) -> Option<Status> {
     return None;
 }
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum RepetitionAnchor {
+    Deadline,
+    Completion,
+}
+
+impl fmt::Display for RepetitionAnchor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RepetitionAnchor::Deadline => write!(f, "deadline"),
+            RepetitionAnchor::Completion => write!(f, "completion"),
+        }
+    }
+}
+
+pub fn read_repetition_anchor(s: &str) -> RepetitionAnchor {
+    match s.to_lowercase().as_str() {
+        "completion" => RepetitionAnchor::Completion,
+        _ => RepetitionAnchor::Deadline,
+    }
+}
+
 #[test]
 fn test_read_status_doneの文字列を変換する() {
     let s = "done";
@@ -97,6 +119,24 @@ fn test_read_status_パーズできなかったときはNoneを返す() {
     let s = "invalid_status";
     let actual = read_status(s);
     assert_eq!(actual, None);
+}
+
+#[test]
+fn test_read_repetition_anchor_deadlineの文字列を変換する() {
+    let actual = read_repetition_anchor("deadline");
+    assert_eq!(actual, RepetitionAnchor::Deadline);
+}
+
+#[test]
+fn test_read_repetition_anchor_completionの文字列を変換する() {
+    let actual = read_repetition_anchor("completion");
+    assert_eq!(actual, RepetitionAnchor::Completion);
+}
+
+#[test]
+fn test_read_repetition_anchor_不正値ならdeadlineを返す() {
+    let actual = read_repetition_anchor("invalid");
+    assert_eq!(actual, RepetitionAnchor::Deadline);
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -707,6 +747,7 @@ pub struct TaskAttr {
     actual_work_seconds: i64,    // 実際の作業時間 (秒)
 
     repetition_interval_days_opt: Option<i64>,
+    repetition_anchor: RepetitionAnchor,
     days_in_advance: i64, // 繰り返しタスクについて、何日前から着手開始可能とするか
 }
 
@@ -728,6 +769,7 @@ impl PartialEq for TaskAttr {
             && self.estimated_work_seconds == other.estimated_work_seconds
             && self.actual_work_seconds == other.actual_work_seconds
             && self.repetition_interval_days_opt == other.repetition_interval_days_opt
+            && self.repetition_anchor == other.repetition_anchor
             && self.days_in_advance == other.days_in_advance
     }
 }
@@ -789,6 +831,7 @@ impl TaskAttr {
             estimated_work_seconds: 900,
             actual_work_seconds: 0,
             repetition_interval_days_opt: None,
+            repetition_anchor: RepetitionAnchor::Deadline,
             days_in_advance: 0,
         }
     }
@@ -958,6 +1001,14 @@ impl TaskAttr {
 
     pub fn get_repetition_interval_days_opt(&self) -> Option<i64> {
         self.repetition_interval_days_opt
+    }
+
+    pub fn set_repetition_anchor(&mut self, repetition_anchor: RepetitionAnchor) {
+        self.repetition_anchor = repetition_anchor;
+    }
+
+    pub fn get_repetition_anchor(&self) -> RepetitionAnchor {
+        self.repetition_anchor
     }
 
     pub fn set_days_in_advance(&mut self, days_in_advance: i64) {
@@ -1198,6 +1249,16 @@ impl Task {
         self.node
             .borrow_data_mut()
             .set_repetition_interval_days_opt(repetition_interval_days_opt);
+    }
+
+    pub fn get_repetition_anchor(&self) -> RepetitionAnchor {
+        self.node.borrow_data().get_repetition_anchor()
+    }
+
+    pub fn set_repetition_anchor(&self, repetition_anchor: RepetitionAnchor) {
+        self.node
+            .borrow_data_mut()
+            .set_repetition_anchor(repetition_anchor);
     }
 
     pub fn get_days_in_advance(&self) -> i64 {
@@ -1888,6 +1949,14 @@ pub fn task_to_yaml(task: &Task) -> Yaml {
         None => {}
     }
 
+    let repetition_anchor = task.get_repetition_anchor();
+    if repetition_anchor != default_attr.get_repetition_anchor() {
+        task_hash.insert(
+            Yaml::String(String::from("repetition_anchor")),
+            Yaml::String(repetition_anchor.to_string()),
+        );
+    }
+
     let days_in_advance = task.get_days_in_advance();
     if days_in_advance != default_attr.get_days_in_advance() {
         task_hash.insert(
@@ -2162,6 +2231,53 @@ id: 67e55044-10b1-426f-9247-bb680e5fe0c8
 create_time: '2023/05/19 01:23:45'
 start_time: '2023/05/19 01:23:45'
 repetition_interval_days: 7
+";
+    let docs = YamlLoader::load_from_str(s).unwrap();
+    let expected_yaml: &Yaml = &docs[0];
+
+    assert_eq!(&actual, expected_yaml);
+}
+
+#[test]
+fn test_task_to_yaml_repetition_anchor_completion() {
+    let mut task = Task::new("タスク1");
+    let id: Uuid = uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8");
+    task.set_id(id);
+    task.set_repetition_anchor(RepetitionAnchor::Completion);
+    let now = Local.with_ymd_and_hms(2023, 5, 19, 01, 23, 45).unwrap();
+    task.set_create_time(now);
+    task.set_start_time(now);
+    let actual = task_to_yaml(&task);
+
+    let s = "
+name: 'タスク1'
+id: 67e55044-10b1-426f-9247-bb680e5fe0c8
+create_time: '2023/05/19 01:23:45'
+start_time: '2023/05/19 01:23:45'
+repetition_anchor: completion
+";
+    let docs = YamlLoader::load_from_str(s).unwrap();
+    let expected_yaml: &Yaml = &docs[0];
+
+    assert_eq!(&actual, expected_yaml);
+}
+
+#[test]
+fn test_task_to_yaml_repetition_anchor_deadlineは出力しない() {
+    let mut task = Task::new("タスク1");
+    let id: Uuid = uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8");
+    task.set_id(id);
+    task.set_repetition_anchor(RepetitionAnchor::Deadline);
+    let now = Local.with_ymd_and_hms(2023, 5, 19, 01, 23, 45).unwrap();
+    task.set_create_time(now);
+    task.set_start_time(now);
+    let actual = task_to_yaml(&task);
+
+    let s = "
+name: 'タスク1'
+id: 67e55044-10b1-426f-9247-bb680e5fe0c8
+create_time: '2023/05/19 01:23:45'
+start_time: '2023/05/19 01:23:45'
 ";
     let docs = YamlLoader::load_from_str(s).unwrap();
     let expected_yaml: &Yaml = &docs[0];


### PR DESCRIPTION
- repetition_anchorを追加し、deadline/completionをYAMLで永続化
- 次回タスク生成時にdeadline基準とcompletion基準を切り替え
- deadlineがない場合は完了時刻基準にfallback
- 基準日ごとの回帰テストを追加